### PR TITLE
remove unused parameters

### DIFF
--- a/vaegan/vaegan.py
+++ b/vaegan/vaegan.py
@@ -19,7 +19,7 @@ def zeros_param( shape, name ):
     return theano.shared( np.zeros( shape, dtype=theano.config.floatX ), name=name )
 
 class VAEGAN( object ):
-    def __init__( self, image_size, phase=0, seed=1234 ):
+    def __init__( self, seed=1234 ):
         self.phase = 0
         self.alpha = 0.5
 


### PR DESCRIPTION
Remove ignored parameters. Also, fixes a problem in the examples when constructing a VAEGAN object where a seed is provided but is passed in as the first argument, which was image_size.